### PR TITLE
Adjust Dockerfiles for best practices

### DIFF
--- a/4.0-jdk7/Dockerfile
+++ b/4.0-jdk7/Dockerfile
@@ -4,8 +4,9 @@ ENV         JAVA_HOME         /usr/lib/jvm/java-7-openjdk-amd64
 ENV         GLASSFISH_HOME    /usr/local/glassfish4
 ENV         PATH              $PATH:$JAVA_HOME/bin:$GLASSFISH_HOME/bin
 
-RUN         apt-get update
-RUN         apt-get install -y curl unzip zip inotify-tools
+RUN         apt-get update && \
+            apt-get install -y curl unzip zip inotify-tools && \
+            rm -rf /var/lib/apt/lists/*
 
 RUN         curl -L -o /tmp/glassfish-4.0.zip http://download.java.net/glassfish/4.0/release/glassfish-4.0.zip && \
             unzip /tmp/glassfish-4.0.zip -d /usr/local && \
@@ -15,5 +16,5 @@ EXPOSE      8080 4848 8181
 
 WORKDIR     /usr/local/glassfish4
 
-CMD         asadmin start-domain && inotifywait -qq -e delete_self $GLASSFISH_HOME/glassfish/domains/domain1/config/pid
-
+# verbose causes the process to remain in the foreground so that docker can track it
+CMD         asadmin start-domain --verbose

--- a/4.1-jdk8/Dockerfile
+++ b/4.1-jdk8/Dockerfile
@@ -4,8 +4,9 @@ ENV         JAVA_HOME         /usr/lib/jvm/java-8-openjdk-amd64
 ENV         GLASSFISH_HOME    /usr/local/glassfish4
 ENV         PATH              $PATH:$JAVA_HOME/bin:$GLASSFISH_HOME/bin
 
-RUN         apt-get update
-RUN         apt-get install -y curl unzip zip inotify-tools
+RUN         apt-get update && \
+            apt-get install -y curl unzip zip inotify-tools && \
+            rm -rf /var/lib/apt/lists/*
 
 RUN         curl -L -o /tmp/glassfish-4.1.zip http://download.java.net/glassfish/4.1/release/glassfish-4.1.zip && \
             unzip /tmp/glassfish-4.1.zip -d /usr/local && \
@@ -15,5 +16,5 @@ EXPOSE      8080 4848 8181
 
 WORKDIR     /usr/local/glassfish4
 
-CMD         asadmin start-domain && inotifywait -qq -e delete_self $GLASSFISH_HOME/glassfish/domains/domain1/config/pid
-
+# verbose causes the process to remain in the foreground so that docker can track it
+CMD         asadmin start-domain --verbose

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -6,6 +6,8 @@ defaultVersion=4.1-jdk8
 versions=( 4.0-jdk7 4.1-jdk8 )
 url='git://github.com/aws/aws-eb-glassfish'
 
+echo '# maintainer: Amazon Web Services <https://aws.amazon.com/contact-us/> (@aws)'
+
 for version in "${versions[@]}"; do
 	commit="$(git log -1 --format='format:%H' -- "$version")"
 	


### PR DESCRIPTION
@zhengyal, we figured a PR would be the fastest way to discuss improvements to the Official Image Dockerfiles.

I moved the `apt-get update` and `install` to the same `RUN` line to help with cache busting and then we can add the `rm` to the `RUN` and save a little space ([docs.docker](https://docs.docker.com/articles/dockerfile_best-practices/#run)).

I added the `--verbose` flag to simplify the `CMD` and make so it only needs one process as it will now run in the foreground ([docs.docker](https://docs.docker.com/articles/dockerfile_best-practices/#run-only-one-process-per-container)).
