### PR TITLE
Switching to openjdk

### DIFF
--- a/4.0-jdk7/Dockerfile
+++ b/4.0-jdk7/Dockerfile
@@ -1,4 +1,4 @@
-FROM        java:7-jdk
+FROM        openjdk:7-jdk-slim
 
 ENV         JAVA_HOME         /usr/lib/jvm/java-7-openjdk-amd64
 ENV         GLASSFISH_HOME    /usr/local/glassfish4

--- a/4.1-jdk8/Dockerfile
+++ b/4.1-jdk8/Dockerfile
@@ -1,4 +1,4 @@
-FROM        java:8-jdk
+FROM        openjdk:8-jdk-slim
 
 ENV         JAVA_HOME         /usr/lib/jvm/java-8-openjdk-amd64
 ENV         GLASSFISH_HOME    /usr/local/glassfish4


### PR DESCRIPTION
#9 

The java docker images are depricated and do seem to work. The 4.0 (jdk7) and 4.1 (jdk8) can be built with the openjdk slim images and are runnable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.